### PR TITLE
Undef issubnormal

### DIFF
--- a/Analysis.h
+++ b/Analysis.h
@@ -28,6 +28,8 @@
 
 #include <string>
 #include <cmath>
+#include <cstddef>
+#include <cstdint>
 #include <iostream>
 #include <fstream>
 #include <vector>

--- a/Analysis.h
+++ b/Analysis.h
@@ -28,6 +28,9 @@
 
 #include <string>
 #include <cmath>
+#ifdef issubnormal
+#undef issubnormal
+#endif
 #include <cstddef>
 #include <cstdint>
 #include <iostream>

--- a/AnalysisLight.h
+++ b/AnalysisLight.h
@@ -25,6 +25,7 @@
 
 #include <string>
 #include <cmath>
+#include <cstdint>
 #include <iostream>
 #include <fstream>
 #include <vector>

--- a/AnalysisLight.h
+++ b/AnalysisLight.h
@@ -25,6 +25,9 @@
 
 #include <string>
 #include <cmath>
+#ifdef issubnormal
+#undef issubnormal
+#endif
 #include <cstdint>
 #include <iostream>
 #include <fstream>

--- a/Cordic.h
+++ b/Cordic.h
@@ -23,6 +23,7 @@
 
 #include <cmath>
 #include <cfenv>
+#include <cstdint>
 #include <iostream>
 #include <iomanip>
 #include <cstring>

--- a/Cordic.h
+++ b/Cordic.h
@@ -22,6 +22,9 @@
 #define _Cordic_h
 
 #include <cmath>
+#ifdef issubnormal
+#undef issubnormal
+#endif
 #include <cfenv>
 #include <cstdint>
 #include <iostream>

--- a/Logger.h
+++ b/Logger.h
@@ -25,6 +25,7 @@
 
 #include <string>
 #include <cmath>
+#include <cstdint>
 #include <iostream>
 
 #ifdef NO_FMT_LL

--- a/Logger.h
+++ b/Logger.h
@@ -25,6 +25,9 @@
 
 #include <string>
 #include <cmath>
+#ifdef issubnormal
+#undef issubnormal
+#endif
 #include <cstdint>
 #include <iostream>
 

--- a/freal.h
+++ b/freal.h
@@ -41,6 +41,7 @@
 #define _freal_h
 
 #include "Cordic.h"
+#include <cstdint>
 
 // #defines:
 //

--- a/mpint.h
+++ b/mpint.h
@@ -37,6 +37,9 @@
 #define _mpint_h
 
 #include <cmath>
+#ifdef issubnormal
+#undef issubnormal
+#endif
 #include <cstddef>
 #include <cstdint>
 #include <iostream>

--- a/mpint.h
+++ b/mpint.h
@@ -37,6 +37,8 @@
 #define _mpint_h
 
 #include <cmath>
+#include <cstddef>
+#include <cstdint>
 #include <iostream>
 #include <string>
 

--- a/test_helpers.h
+++ b/test_helpers.h
@@ -24,6 +24,7 @@
 #define _test_helpers_h
 
 #include "freal.h"
+#include <cstdint>
 
 // some useful macros to avoid redundant typing
 //


### PR DESCRIPTION
Undef issubnormal that is defined by libstdc++

libstdc++ defines the macro `issubnormal` in `math.h` which collides with user defined functions with the same name, in all namespaces.

Both this and #1 is the result of looking into this question:
https://stackoverflow.com/questions/78772081/what-is-error-expected-unqualified-id-before-token